### PR TITLE
Disable swipe navigation on form swiper to enforce validation

### DIFF
--- a/src/utils/swiper-form.ts
+++ b/src/utils/swiper-form.ts
@@ -106,7 +106,7 @@ export const initFormSwiper = () => {
     const swiper = new Swiper(instance as HTMLElement, {
       modules: [Navigation, ...(paginationEl ? [Pagination] : [])],
       slidesPerView: 1,
-      followFinger: true,
+      allowTouchMove: false,
       speed: 300,
       navigation: { nextEl: nextBtn, prevEl: prevBtn },
       pagination: paginationEl ? { el: paginationEl, clickable: false } : false,


### PR DESCRIPTION
Replaces followFinger: true with allowTouchMove: false so mobile users cannot swipe past form slides and bypass field validation.