### PR TITLE
Reduce brand-clarity mobile TBT: defer init + eliminate drag reflow

### DIFF
--- a/src/brand-clarity.ts
+++ b/src/brand-clarity.ts
@@ -1,7 +1,15 @@
 import { initBeforeAfterAnimation } from '$utils/gsap-before-after';
 import { initFormSwiper } from '$utils/swiper-form';
+
 window.Webflow ||= [];
 window.Webflow.push(() => {
-  initFormSwiper();
-  initBeforeAfterAnimation();
+  const init = () => {
+    initFormSwiper();
+    initBeforeAfterAnimation();
+  };
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(init, { timeout: 2000 });
+  } else {
+    setTimeout(init, 200);
+  }
 });

--- a/src/utils/gsap-before-after.ts
+++ b/src/utils/gsap-before-after.ts
@@ -2,108 +2,105 @@ import { gsap } from 'gsap';
 import { Draggable } from 'gsap/Draggable';
 import { InertiaPlugin } from 'gsap/InertiaPlugin';
 
+gsap.registerPlugin(Draggable, InertiaPlugin);
+
+const CONFIG = Object.freeze({
+  startPct: 50,
+  inertia: true,
+  velocityMultiplier: 1.0,
+  resistance: 500,
+  ease: 'power4.out',
+  springBack: false,
+  springDur: 0.6,
+  snapEdge: false,
+  snapEdgeZone: 10,
+  snapCenter: false,
+  snapCenterZone: 5,
+});
+
 export const initBeforeAfterAnimation = () => {
-  document.querySelectorAll<HTMLElement>('.card_before-after_wrap').forEach(() => {
-    /* ── CONFIG ────────────────────────────────────────── */
-    const CONFIG = Object.freeze({
-      startPct: 50,
-      inertia: true,
-      velocityMultiplier: 1.0,
-      resistance: 500,
-      ease: 'power4.out',
-      springBack: false,
-      springDur: 0.6,
-      snapEdge: false,
-      snapEdgeZone: 10,
-      snapCenter: false,
-      snapCenterZone: 5,
-    });
-    /* ── SETUP ─────────────────────────────────────────── */
-    gsap.registerPlugin(Draggable, InertiaPlugin);
-    /* ── SLIDER ────────────────────────────────────────── */
-    const initSlider = (el: HTMLElement) => {
-      const afterWrap = el.querySelector<HTMLElement>('.visual_after_wrap');
-      const divider = el.querySelector<HTMLElement>('.card_before-after_divider');
-      const handle = el.querySelector<HTMLElement>('.card_before-after_draggable');
-      let currentPct: number = CONFIG.startPct;
-      let draggable: Draggable[] | null = null;
-      let snapTween: gsap.core.Tween | null = null;
-      // Convert % to GSAP x offset (handle is anchored at left:50%)
-      const pctToX = (p: number) => (p / 100) * el.offsetWidth - el.offsetWidth / 2;
-      // Read handle position back as %
-      const readPct = () => {
-        const { left: sLeft, width: sWidth } = el.getBoundingClientRect();
-        const { left: hLeft, width: hWidth } = handle!.getBoundingClientRect();
-        return ((hLeft + hWidth / 2 - sLeft) / sWidth) * 100;
-      };
-      const reveal = (p: number) => {
-        currentPct = gsap.utils.clamp(0, 100, p);
-        afterWrap!.style.clipPath = `inset(0 ${100 - currentPct}% 0 0)`;
-        divider!.style.left = `${currentPct}%`;
-      };
-      const getSnapTarget = (p: number): number | null => {
-        if (CONFIG.springBack) return 50;
-        if (CONFIG.snapEdge) {
-          if (p <= CONFIG.snapEdgeZone) return 0;
-          if (p >= 100 - CONFIG.snapEdgeZone) return 100;
-        }
-        if (CONFIG.snapCenter && Math.abs(p - 50) <= CONFIG.snapCenterZone) return 50;
-        return null;
-      };
-      const snapTo = (target: number) => {
-        snapTween?.kill();
-        snapTween = gsap.to(handle, {
-          x: pctToX(target),
-          duration: CONFIG.springBack ? CONFIG.springDur : 0.3,
-          ease: CONFIG.ease,
-          onUpdate: () => reveal(readPct()),
-        });
-      };
-      const onRelease = () => {
-        const target = getSnapTarget(readPct());
-        if (target !== null) snapTo(target);
-      };
-      const build = () => {
-        draggable?.[0].kill();
-        const cfg: Draggable.Vars = {
-          type: 'x',
-          bounds: el,
-          onDrag() {
-            snapTween?.kill();
-            reveal(readPct());
-          },
-          onDragEnd() {
-            onRelease();
-          },
-        };
-        if (CONFIG.inertia) {
-          Object.assign(cfg, {
-            inertia: true,
-            velocityMultiplier: CONFIG.velocityMultiplier,
-            resistance: CONFIG.resistance,
-            onThrowUpdate: () => reveal(readPct()),
-            onThrowComplete: () => onRelease(),
-          });
-        }
-        draggable = Draggable.create(handle, cfg);
-      };
-      const place = (p: number) => {
-        gsap.set(handle, { x: pctToX(p), xPercent: -50, y: 0, yPercent: -50 });
-        reveal(p);
-      };
-      // ResizeObserver handles both initial placement and resize.
-      // Using it as the sole trigger ensures correct positioning even
-      // when the element is hidden (e.g. inside an inactive tab panel)
-      // at script execution time — it fires once the element gains size.
-      let initialized = false;
-      const ro = new ResizeObserver(() => {
-        if (!el.offsetWidth) return;
-        build();
-        place(initialized ? currentPct : CONFIG.startPct);
-        initialized = true;
-      });
-      ro.observe(el);
+  const initSlider = (el: HTMLElement) => {
+    const afterWrap = el.querySelector<HTMLElement>('.visual_after_wrap');
+    const divider = el.querySelector<HTMLElement>('.card_before-after_divider');
+    const handle = el.querySelector<HTMLElement>('.card_before-after_draggable');
+    let currentPct: number = CONFIG.startPct;
+    let containerWidth = 0;
+    let draggable: Draggable[] | null = null;
+    let snapTween: gsap.core.Tween | null = null;
+
+    // Convert % to GSAP x offset (handle is anchored at left:50%)
+    const pctToX = (p: number) => (p / 100) * containerWidth - containerWidth / 2;
+    // Read handle position back as % using GSAP's tracked value — no forced reflow
+    const readPct = () => (((gsap.getProperty(handle!, 'x') as number) / containerWidth + 0.5) * 100);
+    const reveal = (p: number) => {
+      currentPct = gsap.utils.clamp(0, 100, p);
+      afterWrap!.style.clipPath = `inset(0 ${100 - currentPct}% 0 0)`;
+      divider!.style.left = `${currentPct}%`;
     };
-    document.querySelectorAll<HTMLElement>('.card_before-after_element').forEach(initSlider);
-  });
+    const getSnapTarget = (p: number): number | null => {
+      if (CONFIG.springBack) return 50;
+      if (CONFIG.snapEdge) {
+        if (p <= CONFIG.snapEdgeZone) return 0;
+        if (p >= 100 - CONFIG.snapEdgeZone) return 100;
+      }
+      if (CONFIG.snapCenter && Math.abs(p - 50) <= CONFIG.snapCenterZone) return 50;
+      return null;
+    };
+    const snapTo = (target: number) => {
+      snapTween?.kill();
+      snapTween = gsap.to(handle, {
+        x: pctToX(target),
+        duration: CONFIG.springBack ? CONFIG.springDur : 0.3,
+        ease: CONFIG.ease,
+        onUpdate: () => reveal(readPct()),
+      });
+    };
+    const onRelease = () => {
+      const target = getSnapTarget(readPct());
+      if (target !== null) snapTo(target);
+    };
+    const build = () => {
+      draggable?.[0].kill();
+      const cfg: Draggable.Vars = {
+        type: 'x',
+        bounds: el,
+        onDrag() {
+          snapTween?.kill();
+          reveal(readPct());
+        },
+        onDragEnd() {
+          onRelease();
+        },
+      };
+      if (CONFIG.inertia) {
+        Object.assign(cfg, {
+          inertia: true,
+          velocityMultiplier: CONFIG.velocityMultiplier,
+          resistance: CONFIG.resistance,
+          onThrowUpdate: () => reveal(readPct()),
+          onThrowComplete: () => onRelease(),
+        });
+      }
+      draggable = Draggable.create(handle, cfg);
+    };
+    const place = (p: number) => {
+      gsap.set(handle, { x: pctToX(p), xPercent: -50, y: 0, yPercent: -50 });
+      reveal(p);
+    };
+    // ResizeObserver handles both initial placement and resize.
+    // Using it as the sole trigger ensures correct positioning even
+    // when the element is hidden (e.g. inside an inactive tab panel)
+    // at script execution time — it fires once the element gains size.
+    let initialized = false;
+    const ro = new ResizeObserver(() => {
+      if (!el.offsetWidth) return;
+      containerWidth = el.offsetWidth;
+      build();
+      place(initialized ? currentPct : CONFIG.startPct);
+      initialized = true;
+    });
+    ro.observe(el);
+  };
+
+  document.querySelectorAll<HTMLElement>('.card_before-after_element').forEach(initSlider);
 };

--- a/src/utils/gsap-before-after.ts
+++ b/src/utils/gsap-before-after.ts
@@ -31,7 +31,7 @@ export const initBeforeAfterAnimation = () => {
     // Convert % to GSAP x offset (handle is anchored at left:50%)
     const pctToX = (p: number) => (p / 100) * containerWidth - containerWidth / 2;
     // Read handle position back as % using GSAP's tracked value — no forced reflow
-    const readPct = () => (((gsap.getProperty(handle!, 'x') as number) / containerWidth + 0.5) * 100);
+    const readPct = () => ((gsap.getProperty(handle!, 'x') as number) / containerWidth + 0.5) * 100;
     const reveal = (p: number) => {
       currentPct = gsap.utils.clamp(0, 100, p);
       afterWrap!.style.clipPath = `inset(0 ${100 - currentPct}% 0 0)`;


### PR DESCRIPTION
## What changed

**`src/brand-clarity.ts`**
- Wraps `initFormSwiper()` + `initBeforeAfterAnimation()` in `requestIdleCallback({ timeout: 2000 })` with a `setTimeout(200)` fallback for Safari. Both calls now run after the browser's first idle window rather than blocking the main thread during initial paint.

**`src/utils/gsap-before-after.ts`**
- `readPct()` previously called `getBoundingClientRect()` twice on every `pointermove` event during drag — the primary source of hundreds of forced-reflow hits listed in PageSpeed. Replaced with `gsap.getProperty(handle, 'x')` against a `containerWidth` value cached in the `ResizeObserver` callback. Math is the exact inverse of `pctToX`, so behaviour is identical with zero layout cost in the hot path.
- `gsap.registerPlugin(Draggable, InertiaPlugin)` moved to module level — was called on every iteration of the outer loop.
- `CONFIG` moved to module scope — was recreated on every `initBeforeAfterAnimation()` call.
- Removed the outer `.card_before-after_wrap` loop whose callback variable was unused. It called `document.querySelectorAll('.card_before-after_element')` globally, meaning each slider would have been initialized N times with N wrappers present.

## Why

PageSpeed mobile audit showed 1,880ms TBT and a ~5s interaction freeze. The two primary causes in our code were:
1. Synchronous Swiper + GSAP setup blocking the main thread post-paint
2. `getBoundingClientRect()` × 2 on every drag frame inside the before-after component

## Reviewer notes

- The `requestIdleCallback` timeout of 2000ms is intentionally generous — on slow mobile devices "idle" may never come without it, so this guarantees init within 2s while still yielding the thread during the critical window.
- `containerWidth` is only ever written inside `ResizeObserver`, which fires on a layout boundary, so there's no risk of stale reads during drag.
- The outer-loop removal is a correctness fix as well as cleanup — the prior code was latently broken for pages with multiple `.card_before-after_wrap` elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)